### PR TITLE
Fix JS heap out of memory

### DIFF
--- a/extensions/chatgpt/src/type.ts
+++ b/extensions/chatgpt/src/type.ts
@@ -77,6 +77,7 @@ export interface ChatHook {
   setSelectedChatId: Set<string | null>;
   ask: PromiseFunctionWithTwoArg<string, Model>;
   clear: PromiseFunctionNoArg;
+  streamData: Chat | undefined;
 }
 
 export interface ChangeModelProp {

--- a/extensions/chatgpt/src/views/answer-detail.tsx
+++ b/extensions/chatgpt/src/views/answer-detail.tsx
@@ -1,7 +1,13 @@
 import { List } from "@raycast/api";
 import { Chat } from "../type";
 
-export const AnswerDetailView = (props: { chat: Chat; markdown?: string | null | undefined }) => {
-  const { chat, markdown } = props;
-  return <List.Item.Detail markdown={markdown ?? `**${chat.question}**\n\n${chat.answer}`} />;
+export const AnswerDetailView = (props: { 
+  chat: Chat; 
+  streamData?: Chat | undefined;
+}) => {
+  const { chat, streamData } = props;
+  const isStreaming = streamData && streamData.id === chat.id
+  const markdown = `**${chat.question}**\n\n${isStreaming ? streamData.answer : chat.answer}`;
+
+  return <List.Item.Detail markdown={markdown} />;
 };

--- a/extensions/chatgpt/src/views/chat.tsx
+++ b/extensions/chatgpt/src/views/chat.tsx
@@ -87,14 +87,18 @@ export const ChatView = ({
   ) : (
     <List.Section title="Results" subtitle={data.length.toLocaleString()}>
       {sortedChats.map((sortedChat, i) => {
-        const markdown = `**${sortedChat.question}**\n\n${sortedChat.answer}`;
         return (
           <List.Item
             id={sortedChat.id}
             key={sortedChat.id}
             accessories={[{ text: `#${use.chats.data.length - i}` }]}
             title={sortedChat.question}
-            detail={sortedChat && <AnswerDetailView chat={sortedChat} markdown={markdown} />}
+            detail={sortedChat && 
+              <AnswerDetailView 
+                chat={sortedChat}
+                streamData={use.chats.streamData}
+              />
+            }
             actions={use.chats.isLoading ? undefined : getActionPanel(sortedChat)}
           />
         );


### PR DESCRIPTION
## Description

This PR fixes the "JS heap out of memory" when `useStream` feature is enabled. The root cause appears to be due to this code block in the `useChat` hook: 

```typescript
setTimeout(async () => {
  setData((prev) => {
    return prev.map((a) => {
      if (a.id === chat.id) {
        return chat;
      }
      return a;
    });
  });
}, 5);
```

From what I can make sense of, the stream happens so fast that it kept allocating resources for storing the `prev.map` array (all chats history) which caused the heap memory limit for the extension to be reached.

This fix created a new state (`streamData`) as a sort of "buffer" to reduce the size allocated to the heap memory. 

## Screencast

https://user-images.githubusercontent.com/36789245/236106068-1eccf22d-a752-47a6-8129-73ca37ad98ce.mov
